### PR TITLE
Update pkl binary to version 0.25.2

### DIFF
--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -23,7 +23,7 @@ jobs {
       "checkout"
       new RunStep {
         command = """
-          curl -L -o pkl.bin https://github.com/apple/pkl/releases/download/0.25.1/pkl-linux-amd64
+          curl -L -o pkl.bin https://github.com/apple/pkl/releases/download/0.25.2/pkl-linux-amd64
           chmod +x pkl.bin
           PKL_EXEC=$(pwd)/pkl.bin go test ./...
           """

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     - checkout
     - run:
         command: |-
-          curl -L -o pkl.bin https://github.com/apple/pkl/releases/download/0.25.1/pkl-linux-amd64
+          curl -L -o pkl.bin https://github.com/apple/pkl/releases/download/0.25.2/pkl-linux-amd64
           chmod +x pkl.bin
           PKL_EXEC=$(pwd)/pkl.bin go test ./...
     docker:


### PR DESCRIPTION
The command to download the pkl binary in the CircleCI configurations has been updated. 